### PR TITLE
Collapse versions listing

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -8,4 +8,4 @@
 raw_versions="$(rsync -arv rsync://rsync.mirrorservice.org/ftp.mysql.com/Downloads/MySQL-\*/mysql-\[0-9\]\*.zip 2>&1 | awk '/mysql-/{ print $NF }')"
 versions="$(echo $raw_versions | tr ' ' '\n' |  sed -e 's/mysql-\([0-9.]*\).*/\1/' | sed -e 's/\.$//' | sort -u)"
 
-echo $versions | tr ' ' '\n'
+echo $versions | tr '\n' ' '


### PR DESCRIPTION
Fixes a bug in list-all whereby only one version of mysql is echoed to standard out.

### Before
```
% asdf list all mysql
4.1.21
```

### After
```
% asdf list all mysql
4.1.21
4.1.22
5.0.95
5.0.96
5.1.72
5.1.73
5.2.3
5.4.3
5.5.60
5.5.61
5.5.62
5.6.48
5.6.49
5.6.50
5.7.30
5.7.31
5.7.32
6.0.11
8.0.21
8.0.22

```