### PR TITLE
Fix download and installation on Mac

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -47,7 +47,7 @@ install_MySQL() {
         ;;
     esac
     DIR="$(ls -l | grep ^d | awk '{ print $NF }')"
-    rsync -ar "${DIR}/." "${install_path}/."
+    rsync -ar "${DIR:-$PWD}/." "${install_path}/."
   )
 
   # Cleanup

--- a/bin/install
+++ b/bin/install
@@ -18,7 +18,7 @@ install_MySQL() {
       FILE="mysql-${version}-linux*$(arch)*"
       ;;
     Darwin)
-      FILE="mysql-${version}*"
+      FILE="mysql-${version}.zip"
       ;;
     FreeBSD)
       FILE="mysql-${version}-freebsd*"
@@ -26,7 +26,7 @@ install_MySQL() {
   esac
 
   # Very annoyingly, mysql changes compression extensions part way through
-  rsync -zarv --include="*/" --include="*.gz" --include="*.xz" \
+  rsync -zarv --include="*/" --include="*.gz" --include="*.xz" --include="*.zip" \
     --exclude="*" \
     rsync://rsync.mirrorservice.org/ftp.mysql.com/Downloads/MySQL-"${MAJOR}.${MINOR}"/${FILE} \
     ${tmp_download_dir}/. 2>/dev/null

--- a/bin/install
+++ b/bin/install
@@ -18,7 +18,7 @@ install_MySQL() {
       FILE="mysql-${version}-linux*$(arch)*"
       ;;
     Darwin)
-      FILE="mysql-${version}-macos10*"
+      FILE="mysql-${version}*"
       ;;
     FreeBSD)
       FILE="mysql-${version}-freebsd*"

--- a/bin/install
+++ b/bin/install
@@ -45,9 +45,12 @@ install_MySQL() {
       xz)
         tar -xJf $CFILE
         ;;
+      zip)
+        tar -xzvf $CFILE
+        ;;
     esac
     DIR="$(ls -l | grep ^d | awk '{ print $NF }')"
-    rsync -ar "${DIR:-$PWD}/." "${install_path}/."
+    rsync -ar "${DIR}/." "${install_path}/."
   )
 
   # Cleanup


### PR DESCRIPTION
Target installation archives do not appear to be named with a '-macos10' suffix.

### Before

```
% asdf install mysql 5.7.32
+ set -e
++ echo 5.7.32
++ cut -d. -f1
+ MAJOR=5
++ echo 5.7.32
++ cut -d. -f2
+ MINOR=7
++ mktemp -d
+ tmp_download_dir=/var/folders/7c/nwp4zv3574n24s27qgxfxkrm0000gn/T/tmp.Yeke6SthVO
+ case "$(uname -s)" in
++ uname -s
+ FILE=mysql-5.7.32
+ rsync -zarv '--include=*/' '--include=*.gz' '--include=*.xz' '--exclude=*' rsync://rsync.mirrorservice.org/ftp.mysql.com/Downloads/MySQL-5.7/mysql-5.7.32 /var/folders/7c/nwp4zv3574n24s27qgxfxkrm0000gn/T/tmp.Yeke6SthVO/.
-----------------------------------------------------------------------------
Welcome to the University of Kent's UK Mirror Service.

More information can be found at our web site: https://www.mirrorservice.org/
Please send comments or questions to help@mirrorservice.org.
-----------------------------------------------------------------------------

receiving file list ... done

sent 39 bytes  received 17 bytes  22.40 bytes/sec
total size is 0  speedup is 0.00
```

### After

```
% asdf install mysql 5.7.32

+ set -e
++ echo 5.7.32
++ cut -d. -f1
+ MAJOR=5
++ echo 5.7.32
++ cut -d. -f2
+ MINOR=7
++ mktemp -d
+ tmp_download_dir=/var/folders/7c/nwp4zv3574n24s27qgxfxkrm0000gn/T/tmp.sybfRnsQFr
+ case "$(uname -s)" in
++ uname -s
+ FILE=mysql-5.7.32.zip
+ rsync -zarv '--include=*/' '--include=*.gz' '--include=*.xz' '--include=*.zip' '--exclude=*' rsync://rsync.mirrorservice.org/ftp.mysql.com/Downloads/MySQL-5.7/mysql-5.7.32.zip /var/folders/7c/nwp4zv3574n24s27qgxfxkrm0000gn/T/tmp.sybfRnsQFr/.
-----------------------------------------------------------------------------
Welcome to the University of Kent's UK Mirror Service.

More information can be found at our web site: https://www.mirrorservice.org/
Please send comments or questions to help@mirrorservice.org.
-----------------------------------------------------------------------------

receiving file list ... done
mysql-5.7.32.zip

sent 84 bytes  received 75389756 bytes  1187241.57 bytes/sec
total size is 75358211  speedup is 1.00
+ cd /var/folders/7c/nwp4zv3574n24s27qgxfxkrm0000gn/T/tmp.sybfRnsQFr
++ head -1
++ ls -S '*.xz' '*.gz'
ls: cannot access '*.xz': No such file or directory
ls: cannot access '*.gz': No such file or directory
+ CFILE=
+ case "$( echo $CFILE | awk -F. '{ print $NF }')" in
++ echo
++ awk -F. '{ print $NF }'
++ ls -l
++ grep '^d'
++ awk '{ print $NF }'
+ DIR=
+ rsync -ar /var/folders/7c/nwp4zv3574n24s27qgxfxkrm0000gn/T/tmp.sybfRnsQFr/. /Users/jmromer/.asdf/installs/mysql/5.7.32/.
+ rm -rf /var/folders/7c/nwp4zv3574n24s27qgxfxkrm0000gn/T/tmp.sybfRnsQFr
+ echo Successfully installed MySQL 5.7.32
Successfully installed MySQL 5.7.32

```