### PR TITLE
Patch install for new macos11 context

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -18,7 +18,12 @@ install_MySQL() {
       FILE="mysql-${version}-linux*$(arch)*"
       ;;
     Darwin)
-      FILE="mysql-${version}-macos11*"
+      if (( MAJOR <= '8' )); then
+        # the mirrorservice listings for mysql-8.0 have updated to list macos11 as the OS association
+        FILE="mysql-${version}-macos11*"
+      else
+        FILE="mysql-${version}-macos10*"
+      fi
       ;;
     FreeBSD)
       FILE="mysql-${version}-freebsd*"

--- a/bin/install
+++ b/bin/install
@@ -18,7 +18,7 @@ install_MySQL() {
       FILE="mysql-${version}-linux*$(arch)*"
       ;;
     Darwin)
-      FILE="mysql-${version}-macos10*"
+      FILE="mysql-${version}-macos11*"
       ;;
     FreeBSD)
       FILE="mysql-${version}-freebsd*"


### PR DESCRIPTION
The MySQL binaries listed by the mirrorservice.org page for MySQL have updated the naming of the 8.0+ binaries to reflect the new Mac OS 11 release for Darwin users. This patch addresses this naming-convention change.