### PR TITLE
Fix the syntax error

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -18,7 +18,7 @@ install_MySQL() {
       FILE="mysql-${version}-linux*$(arch)*"
       ;;
     Darwin)
-      if (( MAJOR <= '8' )); then
+      if (( MAJOR <= 8 )); then
         # the mirrorservice listings for mysql-8.0 have updated to list macos11 as the OS association
         FILE="mysql-${version}-macos10*"
       else


### PR DESCRIPTION
## What

Fix the syntax error in the `bin/install`

## Why

I got the nfollowing error on my machine.

```
$ asdf install
+ set -e
++ echo 5.7.31
++ cut -d. -f1
+ MAJOR=5
++ echo 5.7.31
++ cut -d. -f2
+ MINOR=7
++ mktemp -d
+ tmp_download_dir=/var/folders/dh/m0820tj97h19hbnzdnvcf4840000gn/T/tmp.ryP9tgMp
+ case "$(uname -s)" in
++ uname -s
+ ((  MAJOR <= '8'  ))
/Users/hota/.asdf/plugins/mysql/bin/install: line 21: ((: MAJOR <= '8' : syntax error: operand expected (error token is "'8' ")
```