### PR TITLE
Use `macos11` OS association for MySQL 8.x

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -17,7 +17,7 @@ install_MySQL() {
       FILE="mysql-${version}-linux*$(arch)*"
       ;;
     Darwin)
-      if (( MAJOR <= 8 )); then
+      if (( MAJOR < 8 )); then
         # the mirrorservice listings for mysql-8.0 have updated to list macos11 as the OS association
         FILE="mysql-${version}-macos10*"
       else


### PR DESCRIPTION
Before this change, it would only use `macos11` OS association
for versions greater than 8.x, which caused the install to fail on
MacOS 11 (at least on my computer).