### PR TITLE
Update readme formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ help, but for some reason, it's an unknown argument.
 
 # Install
 
-`
+```
 asdf plugin-add mysql
 asdf list-all mysql
 asdf install mysql [VERSION]
 asdf global mysql [VERSION]
-`
+```
 
 # Setup
 


### PR DESCRIPTION
On GitHub the installation instructions currently render like this:

<img width="857" alt="image" src="https://user-images.githubusercontent.com/4912864/189922241-41a68b88-be8c-4c2e-9f41-6ecc5aa05ff6.png">

The update in this PR makes the formatting more legible:

<img width="357" alt="image" src="https://user-images.githubusercontent.com/4912864/189922353-6683c8ea-2a06-468d-bbd8-9ff7db661404.png">

